### PR TITLE
Require login for query_schedules

### DIFF
--- a/tableau_rest_api.py
+++ b/tableau_rest_api.py
@@ -1537,7 +1537,7 @@ class TableauRestApi(TableauBase):
         self.start_log_block()
         if self.api_version in [u"2.0", u"2.1"]:
             raise InvalidOptionException(u"query_schedules is only available in Tableau Server 9.3+")
-        schedules = self.query_resource(u"schedules")
+        schedules = self.query_resource(u"schedules", True)
         self.end_log_block()
         return schedules
 


### PR DESCRIPTION
query_schedules would fail with a 404 RecoverableHTTPException because build_api_url would receive `login=False` and use the `self.api_version + u"/sites/" + self.site_luid + u"/" + call` format instead of `self.api_version + u"/" + call` as the tableau API documentation requires.